### PR TITLE
switch name to device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea
+/examples/application_logs
+/microdrop/application_logs

--- a/examples/dropbot_device_monitering_aps_dramatiq_scheduled.py
+++ b/examples/dropbot_device_monitering_aps_dramatiq_scheduled.py
@@ -7,20 +7,20 @@ from microdrop_utils.dramatiq_pub_sub_helpers import publish_message, MessageRou
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 import dramatiq
-from serial.tools.list_ports import grep
+from serial.tools.list_ports import grep, comports
 from microdrop_utils._logger import get_logger
 import re
 
 logger = get_logger(__name__)
 
 
-def check_connected_ports_hwid(id_to_screen, regexp='USB Serial'):
+def check_connected_ports_hwid(hwid = 'USB VID:PID=16C0:0483'):#id_to_screen, regexp='USB Serial'):
     """
     Check connected USB ports for a specific hardware id.
     """
 
     # get connected ports to usb serial
-    connected_ports = grep(regexp)
+    connected_ports = comports()#grep(regexp)
 
     # initialize list to store valid ports
     valid_ports = []
@@ -29,12 +29,13 @@ def check_connected_ports_hwid(id_to_screen, regexp='USB Serial'):
     # try using regex: neglect PID use the VID
     for port in connected_ports:
         # Regex pattern to find the VID in the hwid string
-        pattern = re.compile(f".*{id_to_screen}.*")
+        # pattern = re.compile(f".*{id_to_screen}.*")
 
         # Search for the pattern in the string
-        teensy = re.search(pattern, port.hwid)
+        # teensy = re.search(pattern, port.hwid)
 
-        if bool(teensy):
+        # if bool(teensy):
+        if hwid in port.hwid:
             valid_ports.append(port)
 
     return valid_ports
@@ -68,7 +69,7 @@ class DropBotDeviceConnectionMonitor(HasTraits):
                     if valid_ports:
 
                         # Extract port names
-                        port_names = [port.name for port in valid_ports]
+                        port_names = [port.device for port in valid_ports]
 
                         # Check if there are new port names
                         if port_names != self.port_names:

--- a/examples/dropbot_pub_sub/dropbot_searcher.py
+++ b/examples/dropbot_pub_sub/dropbot_searcher.py
@@ -30,7 +30,7 @@ def check_dropbot_devices_available(hwids_to_check):
     for hwid in hwids_to_check:
         valid_ports = check_connected_ports_hwid(hwid)
         if len(valid_ports) > 0:
-            port_name = str(valid_ports[0].name)
+            port_name = str(valid_ports[0].device)
             # Indicate success by returning the port name
             logger.info(f'DropBot found on port {port_name}, topic is dropbot/info')
             return port_name

--- a/examples/dropbot_qc_test.py
+++ b/examples/dropbot_qc_test.py
@@ -14,7 +14,7 @@ def get_port_name_for_id_to_screen(id_to_screen):
         pattern = re.compile(f".*{id_to_screen}.*")
         teensy = re.search(pattern, port.hwid)
         if bool(teensy):
-            return port.name
+            return port.device
 
 
 # List of on-board self-tests.

--- a/microdrop_utils/hardware_device_monitoring_helpers.py
+++ b/microdrop_utils/hardware_device_monitoring_helpers.py
@@ -31,7 +31,7 @@ def check_devices_available(hwids_to_check):
         valid_ports = check_connected_ports_hwid(hwid)
         # just picking first port, if multiple found.
         if len(valid_ports) > 0:
-            port_name = str(valid_ports[0].name)
+            port_name = str(valid_ports[0].device)
             # Indicate success by returning the port name
             logger.info(f'DropBot found on port {port_name}, topic is dropbot/info')
             return port_name


### PR DESCRIPTION
On windows port.name and port.device can be used interchangeably. Not on linux or mac.